### PR TITLE
build: add dist/index.html to build for Netlify

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "generate": "tsc --project tsconfig.prebuild.json && node ./dist/templates/generateTemplateExamples.js && pnpm build",
     "test": "vitest --run --dir src",
     "check": "tsc --emitDeclarationOnly false --noEmit && eslint 'src/**/*.{ts,tsx}'",
-    "build": "rimraf ./dist ./types && tsc --project tsconfig.json && vite build && cp index.html dist/index.html",
+    "build": "rimraf ./dist ./types && tsc --project tsconfig.json && vite build && sed 's/src=\".*\"/src=\"index.js\"/' index.html > dist/index.html",
     "prepare": "pnpm i -D rimraf vite && pnpm run build"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "generate": "tsc --project tsconfig.prebuild.json && node ./dist/templates/generateTemplateExamples.js && pnpm build",
     "test": "vitest --run --dir src",
     "check": "tsc --emitDeclarationOnly false --noEmit && eslint 'src/**/*.{ts,tsx}'",
-    "build": "rimraf ./dist ./types && tsc --project tsconfig.json && vite build",
+    "build": "rimraf ./dist ./types && tsc --project tsconfig.json && vite build && index.html > dist/index.html",
     "prepare": "pnpm i -D rimraf vite && pnpm run build"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "generate": "tsc --project tsconfig.prebuild.json && node ./dist/templates/generateTemplateExamples.js && pnpm build",
     "test": "vitest --run --dir src",
     "check": "tsc --emitDeclarationOnly false --noEmit && eslint 'src/**/*.{ts,tsx}'",
-    "build": "rimraf ./dist ./types && tsc --project tsconfig.json && vite build && ./index.html > ./dist/index.html",
+    "build": "rimraf ./dist ./types && tsc --project tsconfig.json && vite build && cp index.html dist/index.html",
     "prepare": "pnpm i -D rimraf vite && pnpm run build"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "generate": "tsc --project tsconfig.prebuild.json && node ./dist/templates/generateTemplateExamples.js && pnpm build",
     "test": "vitest --run --dir src",
     "check": "tsc --emitDeclarationOnly false --noEmit && eslint 'src/**/*.{ts,tsx}'",
-    "build": "rimraf ./dist ./types && tsc --project tsconfig.json && vite build && index.html > dist/index.html",
+    "build": "rimraf ./dist ./types && tsc --project tsconfig.json && vite build && ./index.html > ./dist/index.html",
     "prepare": "pnpm i -D rimraf vite && pnpm run build"
   },
   "dependencies": {


### PR DESCRIPTION
seeing if we can spin up a simple Netlify link for main & PR branches to easily share links to the HTML documents, since these aren't currently included in the examples directory or action artifacts. 

https://app.netlify.com/sites/planx-document-templates/overview