### PR TITLE
feat: Add sections to overview.html

### DIFF
--- a/data/example.json
+++ b/data/example.json
@@ -1,1289 +1,539 @@
 {
-	"geojson": {
-		"type": "Feature",
-		"geometry": {
-			"type": "Polygon",
-			"coordinates": [
-				[
-					[
-						-0.7039658725261824,
-						51.655336673788355
-					],
-					[
-						-0.7036319375038286,
-						51.65519356807948
-					],
-					[
-						-0.7035420835018297,
-						51.65524848078866
-					],
-					[
-						-0.7038438320160049,
-						51.655449826819705
-					],
-					[
-						-0.7039658725261824,
-						51.655336673788355
-					]
-				]
-			]
-		},
-		"properties": null
-	},
-	"data": [
-		{
-			"question": "Planning Application Reference",
-			"responses": "6f341f74-aec1-TEST-afa1-0242ac120002"
-		},
-		{
-			"question": "Property Address",
-			"responses": "FLAT 16 RENNIE COURT 11 UPPER GROUND LONDON SE1 9LP"
-		},
-		{
-			"question": "application.fee.reference.govPay",
-			"responses": {
-				"moto": false,
-				"state": {
-					"status": "created",
-					"finished": false
-				},
-				"_links": {
-					"self": {
-						"href": "https://publicapi.payments.service.gov.uk/v1/payments/tvqheq7gje331rlb3he94kbic4",
-						"method": "GET"
-					},
-					"cancel": {
-						"href": "https://publicapi.payments.service.gov.uk/v1/payments/tvqheq7gje331rlb3he94kbic4/cancel",
-						"method": "POST"
-					},
-					"events": {
-						"href": "https://publicapi.payments.service.gov.uk/v1/payments/tvqheq7gje331rlb3he94kbic4/events",
-						"method": "GET"
-					},
-					"refunds": {
-						"href": "https://publicapi.payments.service.gov.uk/v1/payments/tvqheq7gje331rlb3he94kbic4/refunds",
-						"method": "GET"
-					},
-					"next_url": {
-						"href": "https://www.payments.service.gov.uk/secure/46f8a0a8-573a-4bbe-9551-986f9e67fb7c",
-						"method": "GET"
-					},
-					"next_url_post": {
-						"href": "https://www.payments.service.gov.uk/secure",
-						"type": "application/x-www-form-urlencoded",
-						"method": "POST",
-						"params": {
-							"chargeTokenId": "46f8a0a8-573a-4bbe-9551-986f9e67fb7c"
-						}
-					}
-				},
-				"amount": 103,
-				"language": "en",
-				"reference": "6f341f74-aec1-11ed-afa1-0242ac120002",
-				"payment_id": "tvqheq7gje331rlb3he94kbic4",
-				"return_url": "https://planningservices.southwark.gov.uk/apply-for-a-lawful-development-certificate?sessionId=6f341f74-aec1-11ed-afa1-0242ac120002&email=applicant@test.com",
-				"description": "New application",
-				"created_date": "2023-02-01T01:38:10.212Z",
-				"refund_summary": {
-					"status": "pending",
-					"amount_available": 10300,
-					"amount_submitted": 0
-				},
-				"delayed_capture": false,
-				"payment_provider": "stripe",
-				"authorisation_mode": "web",
-				"settlement_summary": {}
-			}
-		},
-		{
-			"question": "application_type",
-			"responses": "lawfulness_certificate"
-		},
-		{
-			"question": "site",
-			"responses": {
-				"town": "LONDON",
-				"uprn": "200003376297",
-				"latitude": 51.5078874,
-				"postcode": "SE1 9LP",
-				"address_1": "FLAT 16, RENNIE COURT, 11, UPPER GROUND",
-				"longitude": -0.1061176
-			}
-		},
-		{
-			"question": "boundary_geojson",
-			"responses": {
-				"type": "Feature",
-				"geometry": {
-					"type": "Polygon",
-					"coordinates": [
-						[
-							[
-								-0.7039658725261824,
-								51.655336673788355
-							],
-							[
-								-0.7036319375038286,
-								51.65519356807948
-							],
-							[
-								-0.7035420835018297,
-								51.65524848078866
-							],
-							[
-								-0.7038438320160049,
-								51.655449826819705
-							],
-							[
-								-0.7039658725261824,
-								51.655336673788355
-							]
-						]
-					]
-				},
-				"properties": null
-			}
-		},
-		{
-			"question": "constraints",
-			"responses": {
-				"tpo": false,
-				"listed": false,
-				"article4": true,
-				"monument": false,
-				"designated": false,
-				"nature.SAC": false,
-				"nature.ASNW": false,
-				"nature.SSSI": false,
-				"designated.SPA": false,
-				"designated.WHS": false,
-				"registeredPark": false,
-				"designated.AONB": false,
-				"article4.southwark.MA": true,
-				"article4.southwark.caz": true,
-				"article4.southwark.hmo": false,
-				"designated.nationalPark": false,
-				"article4.southwark.sunray": false,
-				"article4.southwark.railway": false,
-				"designated.conservationArea": false,
-				"article4.southwark.publichouse": false,
-				"designated.nationalPark.broads": false,
-				"article4.southwark.southernrail": false
-			}
-		},
-		{
-			"question": "work_status",
-			"responses": "proposed"
-		},
-		{
-			"question": "payment_amount",
-			"responses": 10300
-		},
-		{
-			"question": "payment_reference",
-			"responses": "tvqheq7gje331rlb3he94kbic4"
-		},
-		{
-			"question": "result",
-			"responses": {
-				"flag": "Planning permission / Not development",
-				"heading": "Not development",
-				"description": "It looks like the proposed changes may not fall within the legal definition of ‘development’, and therefore would not require planning permission."
-			}
-		},
-		{
-			"question": "user_role",
-			"responses": "applicant"
-		},
-		{
-			"question": "applicant_first_name",
-			"responses": "First"
-		},
-		{
-			"question": "applicant_last_name",
-			"responses": "Last"
-		},
-		{
-			"question": "applicant_phone",
-			"responses": "01234567890"
-		},
-		{
-			"question": "applicant_email",
-			"responses": "applicant@test.com"
-		},
-		{
-			"question": "description",
-			"responses": "Replace existing six windows to six windows, one door to one door.\nSame design, colour, material and sizes. Like to like replacement.\n"
-		},
-		{
-			"metadata": {
-				"portal_name": "_root",
-				"auto_answered": true
-			},
-			"question": "Is the property in London Borough of Southwark?",
-			"responses": [
-				{
-					"value": "Yes"
-				}
-			]
-		},
-		{
-			"metadata": {
-				"policy_refs": [
-					{
-						"text": "Town and Country Planning Act 1990, Part 7, Section 191 &amp; Section 192"
-					}
-				],
-				"portal_name": "_root"
-			},
-			"question": "What are you applying about?",
-			"responses": [
-				{
-					"value": "Proposed changes I want to make in the future"
-				}
-			]
-		},
-		{
-			"metadata": {
-				"policy_refs": [
-					{
-						"text": "Town and Country Planning Act 1990 (Section 55), The Town and Country Planning (General Permitted Development) (England) Order 2015"
-					}
-				],
-				"portal_name": "permitteddevelopment"
-			},
-			"question": "List the changes involved in the project",
-			"responses": [
-				{
-					"value": "Replace windows or doors"
-				}
-			]
-		},
-		{
-			"metadata": {
-				"portal_name": "permitteddevelopment"
-			},
-			"question": "Select all the works to windows or doors",
-			"responses": [
-				{
-					"value": "Replace window with window"
-				},
-				{
-					"value": "Replace door with door"
-				}
-			]
-		},
-		{
-			"metadata": {
-				"portal_name": "Replace windows or doors",
-				"auto_answered": true
-			},
-			"question": "What type of property is it?",
-			"responses": [
-				{
-					"value": "Flat (includes maisonette)"
-				}
-			]
-		},
-		{
-			"metadata": {
-				"policy_refs": [
-					{
-						"text": "Town and Country Planning Act 1990, Part III, Section 55."
-					}
-				],
-				"portal_name": "Replace windows or doors",
-				"auto_answered": true
-			},
-			"question": "What is being replaced?",
-			"responses": [
-				{
-					"value": "Windows replaced with windows"
-				},
-				{
-					"value": "Doors replaced with doors"
-				}
-			]
-		},
-		{
-			"metadata": {
-				"policy_refs": [
-					{
-						"text": "Town and Country Planning Act 1990, Part III, Section 55."
-					}
-				],
-				"portal_name": "Replace windows or doors"
-			},
-			"question": "Are the materials of the new windows similar to the existing windows?",
-			"responses": [
-				{
-					"value": "Yes"
-				}
-			]
-		},
-		{
-			"metadata": {
-				"policy_refs": [
-					{
-						"text": "Town and Country Planning Act 1990, Part III, Section 55."
-					}
-				],
-				"portal_name": "Replace windows or doors",
-				"auto_answered": true
-			},
-			"question": "Are the materials of the new windows similar to the existing windows?",
-			"responses": [
-				{
-					"value": "Yes",
-					"metadata": {
-						"flags": [
-							"Planning permission / Not development"
-						]
-					}
-				}
-			]
-		},
-		{
-			"metadata": {
-				"portal_name": "_root",
-				"auto_answered": true
-			},
-			"question": "Is any part of the property listed?",
-			"responses": [
-				{
-					"value": "No",
-					"metadata": {
-						"flags": [
-							"Listed building consent / Not required"
-						]
-					}
-				}
-			]
-		},
-		{
-			"metadata": {
-				"portal_name": "works-to-trees-filter",
-				"auto_answered": true
-			},
-			"question": "What types of changes does the project involve?",
-			"responses": [
-				{
-					"value": "Alteration"
-				}
-			]
-		},
-		{
-			"metadata": {
-				"portal_name": "works-to-trees-filter",
-				"auto_answered": true
-			},
-			"question": "Have you already told us that you are doing works to a tree or hedge?",
-			"responses": [
-				{
-					"value": "No"
-				}
-			]
-		},
-		{
-			"metadata": {
-				"portal_name": "works-to-trees-filter",
-				"auto_answered": true
-			},
-			"question": "Are there any protected trees on the property?",
-			"responses": [
-				{
-					"value": "No"
-				}
-			]
-		},
-		{
-			"metadata": {
-				"portal_name": "works-to-trees-filter",
-				"auto_answered": true
-			},
-			"question": "Is the site in a conservation area?",
-			"responses": [
-				{
-					"value": "No",
-					"metadata": {
-						"flags": [
-							"Works to trees & hedges / Not required"
-						]
-					}
-				}
-			]
-		},
-		{
-			"metadata": {
-				"portal_name": "more-details",
-				"auto_answered": true
-			},
-			"question": "What does the project involve?",
-			"responses": [
-				{
-					"value": "Add a balcony"
-				}
-			]
-		},
-		{
-			"metadata": {
-				"policy_refs": [
-					{
-						"text": "Greater London Authority Act 1999"
-					}
-				],
-				"portal_name": "more-details",
-				"auto_answered": true
-			},
-			"question": "Is the property in the Greater London Authority area?",
-			"responses": [
-				{
-					"value": "Yes"
-				}
-			]
-		},
-		{
-			"metadata": {
-				"policy_refs": [
-					{
-						"text": "Greater London Authority Act 1999"
-					}
-				],
-				"portal_name": "London Datahub"
-			},
-			"question": "How many properties are on the site?",
-			"responses": [
-				{
-					"value": "Two or more"
-				}
-			]
-		},
-		{
-			"metadata": {
-				"portal_name": "London Datahub"
-			},
-			"question": "Do you know the title numbers of the properties?",
-			"responses": [
-				{
-					"value": "Yes"
-				}
-			]
-		},
-		{
-			"metadata": {
-				"policy_refs": [
-					{
-						"text": "Greater London Authority Act 1999"
-					}
-				],
-				"portal_name": "London Datahub"
-			},
-			"question": "List the title numbers of all properties on the site",
-			"responses": [
-				{
-					"value": "SGL224979"
-				}
-			]
-		},
-		{
-			"metadata": {
-				"policy_refs": [
-					{
-						"text": "Greater London Authority Act 1999"
-					}
-				],
-				"portal_name": "London Datahub"
-			},
-			"question": "Do any of the properties  have an Energy Performance Certificate (EPC)?",
-			"responses": [
-				{
-					"value": "Yes, all of them"
-				}
-			]
-		},
-		{
-			"metadata": {
-				"portal_name": "London Datahub"
-			},
-			"question": "Enter the reference number from the most recent EPC",
-			"responses": [
-				{
-					"value": "1732-2826-6000-0983-4222"
-				}
-			]
-		},
-		{
-			"metadata": {
-				"policy_refs": [
-					{
-						"text": "Greater London Authority Act 1999"
-					}
-				],
-				"portal_name": "London Datahub",
-				"auto_answered": true
-			},
-			"question": "What type of application is this?",
-			"responses": [
-				{
-					"value": "Lawful Development Certificate - Proposed"
-				}
-			]
-		},
-		{
-			"metadata": {
-				"policy_refs": [
-					{
-						"text": "Greater London Authority Act 1999"
-					}
-				],
-				"portal_name": "London Datahub"
-			},
-			"question": "When will the works start?",
-			"responses": [
-				{
-					"value": "2023-03-15"
-				}
-			]
-		},
-		{
-			"metadata": {
-				"policy_refs": [
-					{
-						"text": "Greater London Authority Act 1999"
-					}
-				],
-				"portal_name": "London Datahub"
-			},
-			"question": "When will the works be completed?",
-			"responses": [
-				{
-					"value": "2023-03-20"
-				}
-			]
-		},
-		{
-			"metadata": {
-				"policy_refs": [
-					{
-						"text": "Greater London Authority Act 1999"
-					}
-				],
-				"portal_name": "London Datahub"
-			},
-			"question": "Does the site include parking spaces for any of these?",
-			"responses": [
-				{
-					"value": "None of these"
-				}
-			]
-		},
-		{
-			"metadata": {
-				"portal_name": "about-the-applicant"
-			},
-			"question": "Are you applying on behalf of someone else?",
-			"responses": [
-				{
-					"value": "No"
-				}
-			]
-		},
-		{
-			"metadata": {
-				"portal_name": "about-the-applicant"
-			},
-			"question": "Which of these best describes you?",
-			"responses": [
-				{
-					"value": "Private individual"
-				}
-			]
-		},
-		{
-			"metadata": {
-				"portal_name": "about-the-applicant"
-			},
-			"question": "Title",
-			"responses": [
-				{
-					"value": "Ms"
-				}
-			]
-		},
-		{
-			"metadata": {
-				"portal_name": "about-the-applicant"
-			},
-			"question": "Is your contact address the same as the property address?",
-			"responses": [
-				{
-					"value": "No"
-				}
-			]
-		},
-		{
-			"metadata": {
-				"portal_name": "about-the-applicant"
-			},
-			"question": "Your contact address",
-			"responses": [
-				{
-					"value": "Colchester, 296 LONDON ROAD, STANWAY, Essex, Essex, , CO3 8PB"
-				}
-			]
-		},
-		{
-			"metadata": {
-				"portal_name": "about-the-applicant"
-			},
-			"question": "If a planning officer needs to make a site visit, who should they contact?",
-			"responses": [
-				{
-					"value": "Me, the applicant"
-				}
-			]
-		},
-		{
-			"metadata": {
-				"portal_name": "certificate-of-lawfulness-interest-in-land",
-				"auto_answered": true
-			},
-			"question": "Which of these best describes you?",
-			"responses": [
-				{
-					"value": "Applicant"
-				}
-			]
-		},
-		{
-			"metadata": {
-				"policy_refs": [
-					{
-						"text": "The Town and Country Planning (Development Management Procedure) (England) Order 2015"
-					}
-				],
-				"portal_name": "certificate-of-lawfulness-interest-in-land"
-			},
-			"question": "Which of these best describes your interest in the land?",
-			"responses": [
-				{
-					"value": "Tenant"
-				}
-			]
-		},
-		{
-			"metadata": {
-				"portal_name": "certificate-of-lawfulness-interest-in-land"
-			},
-			"question": "Do you know who owns the site?",
-			"responses": [
-				{
-					"value": "No, I do not know who owns the site"
-				}
-			]
-		},
-		{
-			"metadata": {
-				"portal_name": "community-infrastructure-levy",
-				"auto_answered": true
-			},
-			"question": "What type of application is it?",
-			"responses": [
-				{
-					"value": "Lawful Development Certificate – Proposed changes"
-				}
-			]
-		},
-		{
-			"metadata": {
-				"portal_name": "CIL Liability check",
-				"auto_answered": true
-			},
-			"question": "What does the project involve?",
-			"responses": [
-				{
-					"value": "Alteration",
-					"metadata": {
-						"flags": [
-							"Community infrastructure levy / Not liable"
-						]
-					}
-				}
-			]
-		},
-		{
-			"metadata": {
-				"policy_refs": [
-					{
-						"text": "[Town and Country Planning Act 1990 Section 171B](https://www.legislation.gov.uk/ukpga/1990/8/section/171B)"
-					}
-				],
-				"portal_name": "_root",
-				"auto_answered": true
-			},
-			"question": "What are you applying about?",
-			"responses": [
-				{
-					"value": "Changes that will be made in the future"
-				}
-			]
-		},
-		{
-			"metadata": {
-				"portal_name": "certificate-of-lawfulness-proposed-drawings",
-				"auto_answered": true
-			},
-			"question": "What types of changes does the project involve?",
-			"responses": [
-				{
-					"value": "Alteration"
-				}
-			]
-		},
-		{
-			"metadata": {
-				"portal_name": "certificate-of-lawfulness-proposed-drawings",
-				"auto_answered": true
-			},
-			"question": "Have you already told us that the project will involve works to the roof?",
-			"responses": [
-				{
-					"value": "No"
-				}
-			]
-		},
-		{
-			"metadata": {
-				"portal_name": "certificate-of-lawfulness-proposed-drawings"
-			},
-			"question": "Will the works involve altering the appearance or layout of any roof?",
-			"responses": [
-				{
-					"value": "No"
-				}
-			]
-		},
-		{
-			"metadata": {
-				"portal_name": "certificate-of-lawfulness-proposed-drawings"
-			},
-			"question": "Does the work involve any alterations to ground or floor levels?",
-			"responses": [
-				{
-					"value": "No"
-				}
-			]
-		},
-		{
-			"metadata": {
-				"portal_name": "certificate-of-lawfulness-proposed-drawings"
-			},
-			"question": "Would you like to upload any photographs?",
-			"responses": [
-				{
-					"value": "Yes"
-				}
-			]
-		},
-		{
-			"metadata": {
-				"portal_name": "certificate-of-lawfulness-proposed-drawings"
-			},
-			"question": "Would you like to upload any additional drawings, documents or images?",
-			"responses": [
-				{
-					"value": "No"
-				}
-			]
-		},
-		{
-			"metadata": {
-				"portal_name": "fee-calculator",
-				"auto_answered": true
-			},
-			"question": "What type of planning application are you making?",
-			"responses": [
-				{
-					"value": "Lawful Development Certificate"
-				}
-			]
-		},
-		{
-			"metadata": {
-				"portal_name": "fee-calculator",
-				"auto_answered": true
-			},
-			"question": "What type of changes are you applying for?",
-			"responses": [
-				{
-					"value": "Proposed changes"
-				}
-			]
-		},
-		{
-			"metadata": {
-				"portal_name": "LDC - Proposed",
-				"auto_answered": true
-			},
-			"question": "Is the property a home?",
-			"responses": [
-				{
-					"value": "Yes"
-				}
-			]
-		},
-		{
-			"metadata": {
-				"portal_name": "LDC - Proposed",
-				"auto_answered": true
-			},
-			"question": "What types of changes does the application relate to?",
-			"responses": [
-				{
-					"value": "Alteration"
-				}
-			]
-		},
-		{
-			"metadata": {
-				"policy_refs": [
-					{
-						"text": "The Town and Country Planning (Fees for Applications, Deemed Applications, Requests and Site Visits) (England) Regulations 2012 Schedule 1, Part 2"
-					}
-				],
-				"portal_name": "LDC-P - Householder"
-			},
-			"question": "How many homes does this application relate to?",
-			"responses": [
-				{
-					"value": "1"
-				}
-			]
-		},
-		{
-			"metadata": {
-				"portal_name": "LDC - Proposed",
-				"auto_answered": true
-			},
-			"question": "What alterations are being made to the building?",
-			"responses": [
-				{
-					"value": "Other alterations not on this list"
-				}
-			]
-		},
-		{
-			"metadata": {
-				"portal_name": "Fee Exemptions",
-				"auto_answered": true
-			},
-			"question": "Is the property a home?",
-			"responses": [
-				{
-					"value": "Yes"
-				}
-			]
-		},
-		{
-			"metadata": {
-				"portal_name": "Fee Exemptions",
-				"auto_answered": true
-			},
-			"question": "What works does the project involve?",
-			"responses": [
-				{
-					"value": "Alteration"
-				}
-			]
-		},
-		{
-			"metadata": {
-				"policy_refs": [
-					{
-						"text": "UK Statutory Instruments 2012 No. 2920 Regulation 4, Equalities Act 2010, Section 6 and Children Act 1989, Part 3"
-					}
-				],
-				"portal_name": "Fee Exemptions"
-			},
-			"question": "Are the works being done to provide access for a disabled resident, or to improve their safety, health or comfort?",
-			"responses": [
-				{
-					"value": "No"
-				}
-			]
-		},
-		{
-			"metadata": {
-				"policy_refs": [
-					{
-						"text": "The Town and Country Planning (Fees for Applications, Deemed Applications, Requests and Site Visits) (England) Regulations 2012, Regulation 9"
-					}
-				],
-				"portal_name": "Fee Exemptions"
-			},
-			"question": "Is this application a resubmission?",
-			"responses": [
-				{
-					"value": "No"
-				}
-			]
-		},
-		{
-			"metadata": {
-				"portal_name": "fee-calculator",
-				"auto_answered": true
-			},
-			"question": "Does the application qualify for a disability exemption?",
-			"responses": [
-				{
-					"value": "No"
-				}
-			]
-		},
-		{
-			"metadata": {
-				"portal_name": "fee-calculator",
-				"auto_answered": true
-			},
-			"question": "Does the application qualify for a resubmission exemption?",
-			"responses": [
-				{
-					"value": "No"
-				}
-			]
-		},
-		{
-			"metadata": {
-				"policy_refs": [
-					{
-						"text": "The Town and Country Planning (Fees for Applications, Deemed Applications, Requests and Site Visits) (England) Regulations 2012 Chapter 2, Paragraph 3"
-					}
-				],
-				"portal_name": "Fee Reductions",
-				"auto_answered": true
-			},
-			"question": "Is the site a sports field?",
-			"responses": [
-				{
-					"value": "No"
-				}
-			]
-		},
-		{
-			"metadata": {
-				"policy_refs": [
-					{
-						"text": "The Town and Country Planning (Fees for Applications, Deemed Applications, Requests and Site Visits) (England) Regulations 2012 - Regulation 11"
-					}
-				],
-				"portal_name": "Fee Reductions",
-				"auto_answered": true
-			},
-			"question": "Is the application being made by (or on behalf of) a parish or community council?",
-			"responses": [
-				{
-					"value": "No"
-				}
-			]
-		},
-		{
-			"metadata": {
-				"policy_refs": [
-					{
-						"text": "The Town and Country Planning (Fees for Applications, Deemed Applications, Requests and Site Visits) (England) Regulations 2012 Chapter 2, Paragraph 10"
-					}
-				],
-				"portal_name": "Fee Reductions"
-			},
-			"question": "Are you also submitting another proposal for the same site today?",
-			"responses": [
-				{
-					"value": "No"
-				}
-			]
-		},
-		{
-			"metadata": {
-				"portal_name": "fee-calculator",
-				"auto_answered": true
-			},
-			"question": "Does the application qualify for the sports club fee reduction?",
-			"responses": [
-				{
-					"value": "No"
-				}
-			]
-		},
-		{
-			"metadata": {
-				"policy_refs": [
-					{
-						"text": "The Town and Country Planning (Fees for Applications, Deemed Applications, Requests and Site Visits) (England) Regulations 2012 - Regulation 11"
-					}
-				],
-				"portal_name": "fee-calculator",
-				"auto_answered": true
-			},
-			"question": "Does the application qualify for the parish council reduction?",
-			"responses": [
-				{
-					"value": "No"
-				}
-			]
-		},
-		{
-			"metadata": {
-				"portal_name": "fee-calculator",
-				"auto_answered": true
-			},
-			"question": "Does the application qualify for the alternative application reduction?",
-			"responses": [
-				{
-					"value": "No"
-				}
-			]
-		},
-		{
-			"metadata": {
-				"portal_name": "pre-app-advice-check"
-			},
-			"question": "Did you get any pre-application advice before making this application?",
-			"responses": [
-				{
-					"value": "No"
-				}
-			]
-		},
-		{
-			"metadata": {
-				"portal_name": "declarations"
-			},
-			"question": "Connections with Southwark Council",
-			"responses": [
-				{
-					"value": "None of the above apply to me"
-				}
-			]
-		},
-		{
-			"metadata": {
-				"portal_name": "declarations"
-			},
-			"question": "I confirm that:",
-			"responses": [
-				{
-					"value": "The information contained in this application is truthful, accurate and complete, to the best of my knowledge"
-				}
-			]
-		},
-		{
-			"metadata": {
-				"portal_name": "uniform-translator",
-				"auto_answered": true
-			},
-			"question": "What local planning authority is this application being sent to?",
-			"responses": [
-				{
-					"value": "Southwark"
-				}
-			]
-		},
-		{
-			"metadata": {
-				"portal_name": "uniform-translator",
-				"auto_answered": true
-			},
-			"question": "What is the user's role?",
-			"responses": [
-				{
-					"value": "Applicant"
-				}
-			]
-		},
-		{
-			"metadata": {
-				"portal_name": "uniform-translator",
-				"auto_answered": true
-			},
-			"question": "What is the application type?",
-			"responses": [
-				{
-					"value": "Proposed"
-				}
-			]
-		},
-		{
-			"metadata": {
-				"portal_name": "uniform-translator",
-				"auto_answered": true
-			},
-			"question": "What is the applicant's interest in the land?",
-			"responses": [
-				{
-					"value": "Tenant"
-				}
-			]
-		},
-		{
-			"metadata": {
-				"portal_name": "uniform-translator",
-				"auto_answered": true
-			},
-			"question": "What is the applicant's declared connections?",
-			"responses": [
-				{
-					"value": "None"
-				}
-			]
-		},
-		{
-			"metadata": {
-				"portal_name": "_root",
-				"auto_answered": true
-			},
-			"question": "Does the application qualify for a disability exemption?",
-			"responses": [
-				{
-					"value": "No"
-				}
-			]
-		},
-		{
-			"metadata": {
-				"portal_name": "_root",
-				"auto_answered": true
-			},
-			"question": "Does the application qualify for a resubmission exemption?",
-			"responses": [
-				{
-					"value": "No"
-				}
-			]
-		},
-		{
-			"metadata": "",
-			"question": "File upload: Existing, Plan",
-			"responses": "16rennieCT%20windowA.jpg"
-		},
-		{
-			"metadata": "",
-			"question": "File upload: Existing, Plan",
-			"responses": "16rennieCT%20windowB.jpg"
-		},
-		{
-			"metadata": "",
-			"question": "File upload: Existing, Plan",
-			"responses": "16rennieCT%20windowC.jpg"
-		},
-		{
-			"metadata": "",
-			"question": "File upload: Existing, Plan",
-			"responses": "16rennieCT%20windowD.jpg"
-		},
-		{
-			"metadata": "",
-			"question": "File upload: Existing, Plan",
-			"responses": "16rennieCT%20windowE.jpg"
-		},
-		{
-			"metadata": "",
-			"question": "File upload: Existing, Plan",
-			"responses": "16rennieCT%20windowF.jpg"
-		},
-		{
-			"metadata": "",
-			"question": "File upload: Existing, Plan",
-			"responses": "16rennieCTplan.jpg"
-		},
-		{
-			"metadata": "",
-			"question": "File upload: Proposed, Plan",
-			"responses": "16rennieCTplan.jpg"
-		},
-		{
-			"metadata": "",
-			"question": "File upload: Proposed, Plan",
-			"responses": "16rennieCT%20windowA.jpg"
-		},
-		{
-			"metadata": "",
-			"question": "File upload: Proposed, Plan",
-			"responses": "16rennieCT%20windowB.jpg"
-		},
-		{
-			"metadata": "",
-			"question": "File upload: Proposed, Plan",
-			"responses": "16rennieCT%20windowC.jpg"
-		},
-		{
-			"metadata": "",
-			"question": "File upload: Proposed, Plan",
-			"responses": "16rennieCT%20windowD.jpg"
-		},
-		{
-			"metadata": "",
-			"question": "File upload: Proposed, Plan",
-			"responses": "16rennieCT%20windowE.jpg"
-		},
-		{
-			"metadata": "",
-			"question": "File upload: Existing, Elevation",
-			"responses": "16rennieCT%20windowF.jpg"
-		},
-		{
-			"metadata": "",
-			"question": "File upload: Proposed, Elevation",
-			"responses": "DATA%20SHEET_Alitherm_Series_IMSALS.201504%20%281%29.pdf"
-		},
-		{
-			"metadata": "",
-			"question": "File upload: Proposed, Elevation",
-			"responses": "Hinge%20Press%20Button%202.jpg"
-		},
-		{
-			"metadata": "",
-			"question": "File upload: Proposed, Elevation",
-			"responses": "Hinge%20Press%20Button.jpg"
-		},
-		{
-			"metadata": "",
-			"question": "File upload: Proposed, Elevation",
-			"responses": "39%20River%20Court%201.jpg"
-		},
-		{
-			"metadata": "",
-			"question": "File upload: Proposed, Elevation",
-			"responses": "39%20River%20Court%204.jpg"
-		},
-		{
-			"metadata": "",
-			"question": "File upload: Proposed, Elevation",
-			"responses": "39%20River%20Court%203.jpg"
-		},
-		{
-			"metadata": "",
-			"question": "File upload: Proposed, Elevation",
-			"responses": "39%20River%20Court%202.jpg"
-		},
-		{
-			"metadata": "",
-			"question": "File upload: Proposed, Elevation",
-			"responses": "202301311614.pdf"
-		},
-		{
-			"metadata": "",
-			"question": "File upload: Existing, Photograph",
-			"responses": "screencapture-google-maps-51-507232-0-1055227-3a-51-5y-323-45h-113-78t-data-3m6-1e1-3m4-1sj7K7b-pGmtQz0v2dysBOdw-2e0-7i16384-8i8192-2023-02-01-01_36_21.png"
-		},
-		{
-			"metadata": "",
-			"question": "File upload: Existing, Photograph",
-			"responses": "screencapture-google-maps-51-5077974-0-1055213-3a-75y-243-1h-141-85t-data-3m6-1e1-3m4-1sdtpfhwTB1FWEywsBnmYRpA-2e0-7i16384-8i8192-2023-02-01-01_35_31.png"
-		},
-		{
-			"metadata": "",
-			"question": "File upload: Existing, Photograph",
-			"responses": "screencapture-google-maps-51-5077974-0-1055213-3a-75y-243-1h-141-85t-data-3m6-1e1-3m4-1sdtpfhwTB1FWEywsBnmYRpA-2e0-7i16384-8i8192-2023-02-01-01_35_31.pdf"
-		}
-	]
+  "data": [
+    {
+      "question": "Planning Application Reference",
+      "responses": "fcdaabb2-1feb-47cb-94fa-f9d5148b2efb"
+    },
+    {
+      "question": "Property Address",
+      "responses": "BUCKINGHAMSHIRE COUNCIL COUNCIL OFFICES QUEEN VICTORIA ROAD HIGH WYCOMBE HP11 1BB"
+    },
+    {
+      "question": "Does this demo support Checklists?",
+      "responses": [{ "value": "a" }, { "value": "b" }]
+    },
+    { "question": "application_type", "responses": "lawfulness_certificate" },
+    {
+      "question": "site",
+      "responses": {
+        "town": "HIGH WYCOMBE",
+        "uprn": "200000797602",
+        "latitude": 51.6274191,
+        "postcode": "HP11 1BB",
+        "address_1": "BUCKINGHAMSHIRE COUNCIL, COUNCIL OFFICES, QUEEN VICTORIA ROAD",
+        "longitude": -0.7489513
+      }
+    },
+    {
+      "question": "boundary_geojson",
+      "responses": {
+        "type": "Feature",
+        "geometry": {
+          "type": "Polygon",
+          "coordinates": [
+            [
+              [-0.7491888117037445, 51.62746573090956],
+              [-0.7487475045017631, 51.627460469121615],
+              [-0.7490133156060904, 51.627360716173484],
+              [-0.7491888117037445, 51.62746573090956]
+            ]
+          ]
+        },
+        "properties": null
+      }
+    },
+    {
+      "question": "constraints",
+      "responses": {
+        "tpo": false,
+        "listed": false,
+        "article4": false,
+        "monument": false,
+        "nature.SAC": false,
+        "nature.ASNW": false,
+        "nature.SSSI": false,
+        "designated.SPA": false,
+        "designated.WHS": false,
+        "registeredPark": false,
+        "designated.AONB": false,
+        "designated.nationalPark": false,
+        "designated.conservationArea": true,
+        "article4.buckinghamshire.caz": false,
+        "designated.nationalPark.broads": false
+      }
+    },
+    { "question": "work_status", "responses": "proposed" },
+    {
+      "question": "result",
+      "responses": {
+        "flag": "Planning permission / Not development",
+        "heading": "Not development",
+        "description": "It looks like the proposed changes may not fall within the legal definition of ‘development’, and therefore would not require planning permission."
+      }
+    },
+    { "question": "user_role", "responses": "applicant" },
+    { "question": "applicant_first_name", "responses": "test" },
+    { "question": "applicant_last_name", "responses": "test" },
+    { "question": "applicant_phone", "responses": "1234567" },
+    { "question": "applicant_email", "responses": "dafydd@opensystemslab.io" },
+    { "question": "description", "responses": "test" },
+    {
+      "metadata": { "portal_name": "_root" },
+      "question": "Is the property in Buckinghamshire?",
+      "responses": [{ "value": "Yes" }]
+    },
+    {
+      "metadata": {
+        "policy_refs": [
+          {
+            "text": "Town and Country Planning Act 1990, Part 7, Section 191 &amp; Section 192"
+          }
+        ],
+        "portal_name": "_root"
+      },
+      "question": "What are you applying about?",
+      "responses": [
+        { "value": "Proposed changes I want to make in the future" }
+      ]
+    },
+    {
+      "metadata": { "portal_name": "permitteddevelopment" },
+      "question": "List the changes involved in the project",
+      "responses": [{ "value": "Install a security alarm" }]
+    },
+    {
+      "metadata": {
+        "policy_refs": [
+          { "text": "Town and Country Planning Act 1990, Section 55 (2)" }
+        ],
+        "portal_name": "Alarms",
+        "auto_answered": true
+      },
+      "question": "Is the property in a conservation area?",
+      "responses": [{ "value": "Yes" }]
+    },
+    {
+      "metadata": {
+        "policy_refs": [
+          { "text": "Town and Country Planning Act 1990, Section 55 (2)" }
+        ],
+        "portal_name": "Alarms"
+      },
+      "question": "Do the works include installing a new alarm box to the house?",
+      "responses": [
+        {
+          "value": "No",
+          "metadata": { "flags": ["Planning permission / Not development"] }
+        }
+      ]
+    },
+    {
+      "metadata": { "portal_name": "_root", "auto_answered": true },
+      "question": "Is any part of the property listed?",
+      "responses": [
+        {
+          "value": "No",
+          "metadata": { "flags": ["Listed building consent / Not required"] }
+        }
+      ]
+    },
+    {
+      "metadata": {
+        "portal_name": "works-to-trees-filter",
+        "auto_answered": true
+      },
+      "question": "What types of changes does the project involve?",
+      "responses": [{ "value": "Alteration" }]
+    },
+    {
+      "metadata": {
+        "portal_name": "works-to-trees-filter",
+        "auto_answered": true
+      },
+      "question": "Have you already told us that you are doing works to a tree or hedge?",
+      "responses": [{ "value": "No" }]
+    },
+    {
+      "metadata": {
+        "portal_name": "works-to-trees-filter",
+        "auto_answered": true
+      },
+      "question": "Are there any protected trees on the property?",
+      "responses": [{ "value": "No" }]
+    },
+    {
+      "metadata": {
+        "portal_name": "works-to-trees-filter",
+        "auto_answered": true
+      },
+      "question": "Is the site in a conservation area?",
+      "responses": [{ "value": "Yes" }]
+    },
+    {
+      "metadata": {
+        "policy_refs": [
+          {
+            "text": "The Town and Country Planning (Tree Preservation)(England) Regulations 2012 Part 3"
+          }
+        ],
+        "portal_name": "works-to-trees-filter"
+      },
+      "question": "Might the works affect any tree with a trunk wider than 100mm?",
+      "responses": [
+        {
+          "value": "No, definitely not",
+          "metadata": { "flags": ["Works to trees & hedges / Not required"] }
+        }
+      ]
+    },
+    {
+      "metadata": { "portal_name": "more-details", "auto_answered": true },
+      "question": "What does the project involve?",
+      "responses": [{ "value": "Install a security alarm" }]
+    },
+    {
+      "metadata": {
+        "policy_refs": [{ "text": "Greater London Authority Act 1999" }],
+        "portal_name": "more-details"
+      },
+      "question": "Is the property in the Greater London Authority area?",
+      "responses": [{ "value": "No" }]
+    },
+    {
+      "metadata": { "portal_name": "about-the-applicant" },
+      "question": "Are you applying on behalf of someone else?",
+      "responses": [{ "value": "No" }]
+    },
+    {
+      "metadata": { "portal_name": "about-the-applicant" },
+      "question": "Which of these best describes you?",
+      "responses": [{ "value": "Private individual" }]
+    },
+    {
+      "metadata": { "portal_name": "about-the-applicant" },
+      "question": "Title",
+      "responses": [{ "value": "mr" }]
+    },
+    {
+      "metadata": { "portal_name": "about-the-applicant" },
+      "question": "Is your contact address the same as the property address?",
+      "responses": [{ "value": "Yes" }]
+    },
+    {
+      "metadata": { "portal_name": "about-the-applicant" },
+      "question": "If a planning officer needs to make a site visit, who should they contact?",
+      "responses": [{ "value": "Me, the applicant" }]
+    },
+    {
+      "metadata": {
+        "portal_name": "certificate-of-lawfulness-interest-in-land",
+        "auto_answered": true
+      },
+      "question": "Which of these best describes you?",
+      "responses": [{ "value": "Applicant" }]
+    },
+    {
+      "metadata": {
+        "policy_refs": [
+          {
+            "text": "The Town and Country Planning (Development Management Procedure) (England) Order 2015"
+          }
+        ],
+        "portal_name": "certificate-of-lawfulness-interest-in-land"
+      },
+      "question": "Which of these best describes your interest in the land?",
+      "responses": [{ "value": "Sole owner" }]
+    },
+    {
+      "metadata": {
+        "policy_refs": [
+          {
+            "text": "[Town and Country Planning Act 1990 Section 171B](https://www.legislation.gov.uk/ukpga/1990/8/section/171B)"
+          }
+        ],
+        "portal_name": "_root",
+        "auto_answered": true
+      },
+      "question": "What are you applying about?",
+      "responses": [{ "value": "Changes that will be made in the future" }]
+    },
+    {
+      "metadata": {
+        "portal_name": "certificate-of-lawfulness-proposed-drawings",
+        "auto_answered": true
+      },
+      "question": "What types of changes does the project involve?",
+      "responses": [{ "value": "Alteration" }]
+    },
+    {
+      "metadata": {
+        "portal_name": "certificate-of-lawfulness-proposed-drawings",
+        "auto_answered": true
+      },
+      "question": "Have you already told us that the project will involve works to the roof?",
+      "responses": [{ "value": "No" }]
+    },
+    {
+      "metadata": {
+        "portal_name": "certificate-of-lawfulness-proposed-drawings"
+      },
+      "question": "Will the works involve altering the appearance or layout of any roof?",
+      "responses": [{ "value": "No" }]
+    },
+    {
+      "metadata": {
+        "portal_name": "certificate-of-lawfulness-proposed-drawings"
+      },
+      "question": "Does the work involve any alterations to ground or floor levels?",
+      "responses": [{ "value": "No" }]
+    },
+    {
+      "metadata": {
+        "portal_name": "certificate-of-lawfulness-proposed-drawings"
+      },
+      "question": "Would you like to upload any photographs?",
+      "responses": [{ "value": "No" }]
+    },
+    {
+      "metadata": {
+        "portal_name": "certificate-of-lawfulness-proposed-drawings"
+      },
+      "question": "Would you like to upload any additional drawings, documents or images?",
+      "responses": [{ "value": "No" }]
+    },
+    {
+      "metadata": { "portal_name": "fee-calculator", "auto_answered": true },
+      "question": "What type of planning application are you making?",
+      "responses": [{ "value": "Lawful Development Certificate" }]
+    },
+    {
+      "metadata": { "portal_name": "fee-calculator", "auto_answered": true },
+      "question": "What type of changes are you applying for?",
+      "responses": [{ "value": "Proposed changes" }]
+    },
+    {
+      "metadata": { "portal_name": "LDC - Proposed", "auto_answered": true },
+      "question": "Is the property a home?",
+      "responses": [{ "value": "No" }]
+    },
+    {
+      "metadata": { "portal_name": "LDC - Proposed", "auto_answered": true },
+      "question": "What types of changes does the application relate to?",
+      "responses": [{ "value": "Alteration" }]
+    },
+    {
+      "metadata": { "portal_name": "LDC - Proposed", "auto_answered": true },
+      "question": "What will the alterations involve?",
+      "responses": [{ "value": "Other alterations" }]
+    },
+    {
+      "metadata": { "portal_name": "Fee Exemptions", "auto_answered": true },
+      "question": "Is the property a home?",
+      "responses": [{ "value": "No" }]
+    },
+    {
+      "metadata": { "portal_name": "Fee Exemptions", "auto_answered": true },
+      "question": "What type of changes does the project involve?",
+      "responses": [{ "value": "Alteration" }]
+    },
+    {
+      "metadata": { "portal_name": "Fee Exemptions" },
+      "question": "Are the public allowed to access the building?",
+      "responses": [{ "value": "No" }]
+    },
+    {
+      "metadata": {
+        "policy_refs": [
+          {
+            "text": "The Town and Country Planning (Fees for Applications, Deemed Applications, Requests and Site Visits) (England) Regulations 2012, Regulation 9"
+          }
+        ],
+        "portal_name": "Fee Exemptions"
+      },
+      "question": "Is this application a resubmission?",
+      "responses": [{ "value": "Yes" }]
+    },
+    {
+      "metadata": {
+        "policy_refs": [
+          {
+            "text": "The Town and Country Planning (Fees for Applications, Deemed Applications, Requests and Site Visits) (England) Regulations 2012, Regulation 8"
+          }
+        ],
+        "portal_name": "Fee Exemptions"
+      },
+      "question": "Is this the first time you have resubmitted an application for this site?",
+      "responses": [{ "value": "Yes" }]
+    },
+    {
+      "metadata": { "portal_name": "Fee Exemptions", "auto_answered": true },
+      "question": "What type of application is this?",
+      "responses": [{ "value": "Lawful Development Certificate" }]
+    },
+    {
+      "metadata": { "portal_name": "Fee Exemptions" },
+      "question": "What was the original application's reference number?",
+      "responses": [{ "value": "test" }]
+    },
+    {
+      "metadata": {
+        "policy_refs": [
+          { "text": "UK Statutory Instruments 2012 No. 2920 Regulation 8" }
+        ],
+        "portal_name": "Fee Exemptions"
+      },
+      "question": "To qualify for a fee exemption, the proposed works must be of a similar description to the original application",
+      "responses": [{ "value": "I understand" }]
+    },
+    {
+      "metadata": { "portal_name": "Fee Exemptions" },
+      "question": "What was the result of the original application?",
+      "responses": [{ "value": "It was not determined in time" }]
+    },
+    {
+      "metadata": {
+        "policy_refs": [
+          { "text": "UK Statutory Instruments 2012 No. 2920 Regulation 8" }
+        ],
+        "portal_name": "Fee Exemptions"
+      },
+      "question": "When did the original application time out?",
+      "responses": [{ "value": "Within the last 12 months" }]
+    },
+    {
+      "metadata": { "portal_name": "fee-calculator", "auto_answered": true },
+      "question": "Does the application qualify for a disability exemption?",
+      "responses": [{ "value": "No" }]
+    },
+    {
+      "metadata": { "portal_name": "fee-calculator", "auto_answered": true },
+      "question": "Does the application qualify for a resubmission exemption?",
+      "responses": [{ "value": "Yes" }]
+    },
+    {
+      "metadata": { "portal_name": "pre-app-advice-check" },
+      "question": "Did you get any pre-application advice before making this application?",
+      "responses": [{ "value": "No" }]
+    },
+    {
+      "metadata": { "portal_name": "declarations" },
+      "question": "Connections with Buckinghamshire Council",
+      "responses": [{ "value": "None of the above apply to me" }]
+    },
+    {
+      "metadata": {
+        "policy_refs": [
+          {
+            "text": "The Town and Country Planning (General Permitted Development) (England) Order 2015 Schedule 2, Part 1, Class A.1 (b)"
+          }
+        ],
+        "portal_name": "Rear and side extensions to houses"
+      },
+      "question": "How much of the property is covered by extensions and outbuildings?",
+      "responses": [
+        {
+          "value": "50% or less of the available area around the original house",
+          "metadata": {
+            "flags": [
+              "Planning permission / Permitted development"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "metadata": { "portal_name": "declarations" },
+      "question": "I confirm that:",
+      "responses": [
+        {
+          "value": "The information contained in this application is truthful, accurate and complete, to the best of my knowledge"
+        }
+      ]
+    },
+    {
+      "metadata": { "portal_name": "uniform-translator" },
+      "question": "What local planning authority is this application being sent to?",
+      "responses": [{ "value": "Wycombe" }]
+    },
+    {
+      "metadata": {
+        "portal_name": "uniform-translator",
+        "auto_answered": true
+      },
+      "question": "What is the user's role?",
+      "responses": [{ "value": "Applicant" }]
+    },
+    {
+      "metadata": {
+        "portal_name": "uniform-translator",
+        "auto_answered": true
+      },
+      "question": "What is the application type?",
+      "responses": [{ "value": "Proposed" }]
+    },
+    {
+      "metadata": {
+        "portal_name": "uniform-translator",
+        "auto_answered": true
+      },
+      "question": "What is the applicant's interest in the land?",
+      "responses": [{ "value": "Owner" }]
+    },
+    {
+      "metadata": {
+        "portal_name": "uniform-translator",
+        "auto_answered": true
+      },
+      "question": "What is the applicant's declared connections?",
+      "responses": [{ "value": "None" }]
+    },
+    {
+      "metadata": { "portal_name": "_root", "auto_answered": true },
+      "question": "Does the application qualify for a disability exemption?",
+      "responses": [{ "value": "No" }]
+    },
+    {
+      "metadata": { "portal_name": "_root", "auto_answered": true },
+      "question": "Does the application qualify for a resubmission exemption?",
+      "responses": [{ "value": "Yes" }]
+    },
+    {
+      "question": "File upload: Existing, Plan",
+      "responses": "WhatsApp%20Image%202022-07-01%20at%2011.18.03%20AM%20%281%29.jpeg"
+    },
+    {
+      "question": "File upload: Proposed, Plan",
+      "responses": "WhatsApp%20Image%202022-07-01%20at%2011.18.03%20AM%20%281%29.jpeg"
+    },
+    {
+      "question": "File upload: Existing, Elevation",
+      "responses": "WhatsApp%20Image%202022-07-01%20at%2011.18.03%20AM%20%281%29.jpeg"
+    },
+    {
+      "question": "File upload: Proposed, Elevation",
+      "responses": "WhatsApp%20Image%202022-07-01%20at%2011.18.03%20AM%20%281%29.jpeg"
+    }
+  ],
+  "files": [
+    "https://api.editor.planx.dev/file/private/cf9yx466/WhatsApp%20Image%202022-07-01%20at%2011.18.03%20AM%20%281%29.jpeg",
+    "https://api.editor.planx.dev/file/private/hgvzjumf/WhatsApp%20Image%202022-07-01%20at%2011.18.03%20AM%20%281%29.jpeg",
+    "https://api.editor.planx.dev/file/private/g3yw5cc3/WhatsApp%20Image%202022-07-01%20at%2011.18.03%20AM%20%281%29.jpeg",
+    "https://api.editor.planx.dev/file/private/nq62zbns/WhatsApp%20Image%202022-07-01%20at%2011.18.03%20AM%20%281%29.jpeg"
+  ],
+  "geojson": {
+    "type": "Feature",
+    "geometry": {
+      "type": "Polygon",
+      "coordinates": [
+        [
+          [-0.7491888117037445, 51.62746573090956],
+          [-0.7487475045017631, 51.627460469121615],
+          [-0.7490133156060904, 51.627360716173484],
+          [-0.7491888117037445, 51.62746573090956]
+        ]
+      ]
+    },
+    "properties": null
+  },
+  "sessionId": "fcdaabb2-1feb-47cb-94fa-f9d5148b2efb"
 }

--- a/data/exampleWithSections.json
+++ b/data/exampleWithSections.json
@@ -1,0 +1,881 @@
+{
+  "data": [
+    {
+      "responses": [
+        {
+          "value": "Yes"
+        }
+      ],
+      "metadata": {
+        "portal_name": "_root",
+        "auto_answered": true,
+        "section_name": "About the property"
+      },
+      "question": "Is the property in Buckinghamshire?"
+    },
+    {
+      "responses": [
+        {
+          "value": "Proposed changes I want to make in the future"
+        }
+      ],
+      "metadata": {
+        "portal_name": "_root",
+        "section_name": "About the project",
+        "policy_refs": [
+          {
+            "text": "Town and Country Planning Act 1990, Part 7, Section 191 &amp; Section 192"
+          }
+        ]
+      },
+      "question": "What are you applying about?"
+    },
+    {
+      "responses": [
+        {
+          "value": "Install a security alarm"
+        }
+      ],
+      "metadata": {
+        "portal_name": "permitteddevelopment",
+        "section_name": "About the project",
+        "policy_refs": [
+          {
+            "text": "Town and Country Planning Act 1990 (Section 55), The Town and Country Planning (General Permitted Development) (England) Order 2015"
+          }
+        ]
+      },
+      "question": "List the changes involved in the project"
+    },
+    {
+      "responses": [
+        {
+          "value": "No",
+          "metadata": {
+            "flags": [
+              "Planning permission / Permitted development"
+            ]
+          }
+        }
+      ],
+      "metadata": {
+        "portal_name": "Alarms",
+        "auto_answered": true,
+        "section_name": "About the project",
+        "policy_refs": [
+          {
+            "text": "Town and Country Planning Act 1990, Section 55 (2)"
+          }
+        ]
+      },
+      "question": "Is the property in a conservation area?"
+    },
+    {
+      "responses": [
+        {
+          "value": "No"
+        }
+      ],
+      "metadata": {
+        "portal_name": "_root",
+        "auto_answered": true,
+        "section_name": "About the project"
+      },
+      "question": "Is the property subject to any Article 4 directions?"
+    },
+    {
+      "responses": [
+        {
+          "value": "No",
+          "metadata": {
+            "flags": [
+              "Listed building consent / Not required"
+            ]
+          }
+        }
+      ],
+      "metadata": {
+        "portal_name": "Warnings",
+        "auto_answered": true,
+        "section_name": "About the project"
+      },
+      "question": "Is any part of the property listed?"
+    },
+    {
+      "responses": [
+        {
+          "value": "Alteration"
+        }
+      ],
+      "metadata": {
+        "portal_name": "works-to-trees-filter",
+        "auto_answered": true,
+        "section_name": "Works to trees"
+      },
+      "question": "What types of changes does the project involve?"
+    },
+    {
+      "responses": [
+        {
+          "value": "No"
+        }
+      ],
+      "metadata": {
+        "portal_name": "works-to-trees-filter",
+        "auto_answered": true,
+        "section_name": "Works to trees"
+      },
+      "question": "Have you already told us that you are doing works to a tree or hedge?"
+    },
+    {
+      "responses": [
+        {
+          "value": "No"
+        }
+      ],
+      "metadata": {
+        "portal_name": "works-to-trees-filter",
+        "auto_answered": true,
+        "section_name": "Works to trees"
+      },
+      "question": "Are there any protected trees on the property?"
+    },
+    {
+      "responses": [
+        {
+          "value": "No",
+          "metadata": {
+            "flags": [
+              "Works to trees & hedges / Not required"
+            ]
+          }
+        }
+      ],
+      "metadata": {
+        "portal_name": "works-to-trees-filter",
+        "auto_answered": true,
+        "section_name": "Works to trees"
+      },
+      "question": "Is the site in a conservation area?"
+    },
+    {
+      "responses": [
+        {
+          "value": "No"
+        }
+      ],
+      "metadata": {
+        "portal_name": "_root",
+        "auto_answered": true,
+        "section_name": "Works to trees"
+      },
+      "question": "Should the applicant also apply for Works to Trees Consent?"
+    },
+    {
+      "responses": [
+        {
+          "value": "Proposed changes I want to make in the future"
+        }
+      ],
+      "metadata": {
+        "portal_name": "more-details",
+        "auto_answered": true,
+        "section_name": "Works to trees"
+      },
+      "question": "What are you applying about?"
+    },
+    {
+      "responses": [
+        {
+          "value": "Alterations"
+        }
+      ],
+      "metadata": {
+        "portal_name": "more-details",
+        "auto_answered": true,
+        "section_name": "Works to trees"
+      },
+      "question": "What do the works involve?"
+    },
+    {
+      "responses": [
+        {
+          "value": "Install a security alarm"
+        }
+      ],
+      "metadata": {
+        "portal_name": "more-details",
+        "auto_answered": true,
+        "section_name": "Works to trees"
+      },
+      "question": "What does the project involve?"
+    },
+    {
+      "responses": [
+        {
+          "value": "No"
+        }
+      ],
+      "metadata": {
+        "portal_name": "more-details",
+        "auto_answered": true,
+        "section_name": "Works to trees"
+      },
+      "question": "Do the changes involve the creation of any new homes?"
+    },
+    {
+      "responses": [
+        {
+          "value": "No"
+        }
+      ],
+      "metadata": {
+        "portal_name": "more-details",
+        "auto_answered": true,
+        "section_name": "Works to trees",
+        "policy_refs": [
+          {
+            "text": "Greater London Authority Act 1999"
+          }
+        ]
+      },
+      "question": "Is the property in the Greater London Authority area?"
+    },
+    {
+      "responses": [
+        {
+          "value": "No"
+        }
+      ],
+      "metadata": {
+        "portal_name": "about-the-applicant",
+        "section_name": "About you"
+      },
+      "question": "Are you applying on behalf of someone else?"
+    },
+    {
+      "responses": [
+        {
+          "value": "Private individual"
+        }
+      ],
+      "metadata": {
+        "portal_name": "about-the-applicant",
+        "section_name": "About you"
+      },
+      "question": "Which of these best describes you?"
+    },
+    {
+      "responses": [
+        {
+          "value": "mr test test 345 dafydd@opensystemslab.io"
+        }
+      ],
+      "metadata": {
+        "portal_name": "about-the-applicant",
+        "section_name": "About you"
+      },
+      "question": "Enter your contact details"
+    },
+    {
+      "responses": [
+        {
+          "value": "Yes"
+        }
+      ],
+      "metadata": {
+        "portal_name": "about-the-applicant",
+        "section_name": "About you"
+      },
+      "question": "Is your contact address the same as the property address?"
+    },
+    {
+      "responses": [
+        {
+          "value": "Me, the applicant"
+        }
+      ],
+      "metadata": {
+        "portal_name": "about-the-applicant",
+        "section_name": "About you"
+      },
+      "question": "If a planning officer needs to make a site visit, who should they contact?"
+    },
+    {
+      "responses": [
+        {
+          "value": "Applicant"
+        }
+      ],
+      "metadata": {
+        "portal_name": "ownership",
+        "auto_answered": true,
+        "section_name": "Ownership"
+      },
+      "question": "Which of these best describes you?"
+    },
+    {
+      "responses": [
+        {
+          "value": "Sole owner"
+        }
+      ],
+      "metadata": {
+        "portal_name": "ownership",
+        "section_name": "Ownership",
+        "policy_refs": [
+          {
+            "text": "The Town and Country Planning (Development Management Procedure) (England) Order 2015"
+          }
+        ]
+      },
+      "question": "Which of these best describes your interest in the land?"
+    },
+    {
+      "responses": [
+        {
+          "value": "Changes that will be made in the future"
+        }
+      ],
+      "metadata": {
+        "portal_name": "_root",
+        "auto_answered": true,
+        "section_name": "Upload drawings",
+        "policy_refs": [
+          {
+            "text": "[Town and Country Planning Act 1990 Section 171B](https://www.legislation.gov.uk/ukpga/1990/8/section/171B)"
+          }
+        ]
+      },
+      "question": "What are you applying about?"
+    },
+    {
+      "responses": [
+        {
+          "value": "Alteration"
+        }
+      ],
+      "metadata": {
+        "portal_name": "certificate-of-lawfulness-proposed-drawings",
+        "auto_answered": true,
+        "section_name": "Upload drawings"
+      },
+      "question": "What types of changes does the project involve?"
+    },
+    {
+      "responses": [
+        {
+          "value": "No"
+        }
+      ],
+      "metadata": {
+        "portal_name": "certificate-of-lawfulness-proposed-drawings",
+        "auto_answered": true,
+        "section_name": "Upload drawings"
+      },
+      "question": "Have you already told us that the project will involve works to the roof?"
+    },
+    {
+      "responses": [
+        {
+          "value": "No"
+        }
+      ],
+      "metadata": {
+        "portal_name": "certificate-of-lawfulness-proposed-drawings",
+        "section_name": "Upload drawings"
+      },
+      "question": "Will the works involve altering the appearance or layout of any roof?"
+    },
+    {
+      "responses": [
+        {
+          "value": "No"
+        }
+      ],
+      "metadata": {
+        "portal_name": "certificate-of-lawfulness-proposed-drawings",
+        "section_name": "Upload drawings"
+      },
+      "question": "Does the work involve any alterations to ground or floor levels?"
+    },
+    {
+      "responses": [
+        {
+          "value": "No"
+        }
+      ],
+      "metadata": {
+        "portal_name": "certificate-of-lawfulness-proposed-drawings",
+        "section_name": "Upload drawings"
+      },
+      "question": "Would you like to upload any photographs?"
+    },
+    {
+      "responses": [
+        {
+          "value": "No"
+        }
+      ],
+      "metadata": {
+        "portal_name": "certificate-of-lawfulness-proposed-drawings",
+        "section_name": "Upload drawings"
+      },
+      "question": "Would you like to upload any additional drawings, documents or images?"
+    },
+    {
+      "responses": [
+        {
+          "value": "Lawful Development Certificate"
+        }
+      ],
+      "metadata": {
+        "portal_name": "fee-calculator",
+        "auto_answered": true,
+        "section_name": "About your application"
+      },
+      "question": "What type of planning application are you making?"
+    },
+    {
+      "responses": [
+        {
+          "value": "Proposed changes"
+        }
+      ],
+      "metadata": {
+        "portal_name": "fee-calculator",
+        "auto_answered": true,
+        "section_name": "About your application"
+      },
+      "question": "What type of changes are you applying for?"
+    },
+    {
+      "responses": [
+        {
+          "value": "Yes"
+        }
+      ],
+      "metadata": {
+        "portal_name": "LDC - Proposed",
+        "auto_answered": true,
+        "section_name": "About your application"
+      },
+      "question": "Is the property a home?"
+    },
+    {
+      "responses": [
+        {
+          "value": "Alteration"
+        }
+      ],
+      "metadata": {
+        "portal_name": "LDC - Proposed",
+        "auto_answered": true,
+        "section_name": "About your application"
+      },
+      "question": "What types of changes does the application relate to?"
+    },
+    {
+      "responses": [
+        {
+          "value": "1"
+        }
+      ],
+      "metadata": {
+        "portal_name": "LDC-P - Householder",
+        "section_name": "About your application",
+        "policy_refs": [
+          {
+            "text": "The Town and Country Planning (Fees for Applications, Deemed Applications, Requests and Site Visits) (England) Regulations 2012 Schedule 1, Part 2"
+          }
+        ]
+      },
+      "question": "How many homes does this application relate to?"
+    },
+    {
+      "responses": [
+        {
+          "value": "Other alterations not on this list"
+        }
+      ],
+      "metadata": {
+        "portal_name": "LDC - Proposed",
+        "auto_answered": true,
+        "section_name": "About your application"
+      },
+      "question": "What alterations are being made to the building?"
+    },
+    {
+      "responses": [
+        {
+          "value": "Yes"
+        }
+      ],
+      "metadata": {
+        "portal_name": "Fee Exemptions",
+        "auto_answered": true,
+        "section_name": "About your application"
+      },
+      "question": "Is the property a home?"
+    },
+    {
+      "responses": [
+        {
+          "value": "Alteration"
+        }
+      ],
+      "metadata": {
+        "portal_name": "Fee Exemptions",
+        "auto_answered": true,
+        "section_name": "About your application"
+      },
+      "question": "What works does the project involve?"
+    },
+    {
+      "responses": [
+        {
+          "value": "No"
+        }
+      ],
+      "metadata": {
+        "portal_name": "Fee Exemptions",
+        "section_name": "About your application",
+        "policy_refs": [
+          {
+            "text": "The Town and Country Planning (Fees for Applications, Deemed Applications, Requests and Site Visits) (England) Regulations 2012, Regulation 14UK Statutory Instruments 2012 No. 2920 Regulation 4, Equalities Act 2010, Section 6 Children Act 1989, Part 3"
+          }
+        ]
+      },
+      "question": "Is the sole purpose of the project to support the needs of a disabled resident?"
+    },
+    {
+      "responses": [
+        {
+          "value": "Yes"
+        }
+      ],
+      "metadata": {
+        "portal_name": "Fee Exemptions",
+        "section_name": "About your application",
+        "policy_refs": [
+          {
+            "text": "The Town and Country Planning (Fees for Applications, Deemed Applications, Requests and Site Visits) (England) Regulations 2012, Regulation 9"
+          }
+        ]
+      },
+      "question": "Is this application a resubmission?"
+    },
+    {
+      "responses": [
+        {
+          "value": "Yes"
+        }
+      ],
+      "metadata": {
+        "portal_name": "Fee Exemptions",
+        "section_name": "About your application",
+        "policy_refs": [
+          {
+            "text": "The Town and Country Planning (Fees for Applications, Deemed Applications, Requests and Site Visits) (England) Regulations 2012, Regulation 8"
+          }
+        ]
+      },
+      "question": "Is this the first time you have resubmitted an application for this site?"
+    },
+    {
+      "responses": [
+        {
+          "value": "Lawful Development Certificate"
+        }
+      ],
+      "metadata": {
+        "portal_name": "Fee Exemptions",
+        "auto_answered": true,
+        "section_name": "About your application"
+      },
+      "question": "What type of application is this?"
+    },
+    {
+      "responses": [
+        {
+          "value": "test"
+        }
+      ],
+      "metadata": {
+        "portal_name": "Fee Exemptions",
+        "section_name": "About your application"
+      },
+      "question": "What was the original application's reference number?"
+    },
+    {
+      "responses": [
+        {
+          "value": "I understand"
+        }
+      ],
+      "metadata": {
+        "portal_name": "Fee Exemptions",
+        "section_name": "About your application",
+        "policy_refs": [
+          {
+            "text": "The Town and Country Planning (Fees for Applications, Deemed Applications, Requests and Site Visits) (England) Regulations 2012, Regulation 14"
+          }
+        ]
+      },
+      "question": "To qualify for a fee exemption, the proposed works must be of a similar description to the original application"
+    },
+    {
+      "responses": [
+        {
+          "value": "It was not determined in time"
+        }
+      ],
+      "metadata": {
+        "portal_name": "Fee Exemptions",
+        "section_name": "About your application"
+      },
+      "question": "What was the result of the original application?"
+    },
+    {
+      "responses": [
+        {
+          "value": "Within the last 12 months"
+        }
+      ],
+      "metadata": {
+        "portal_name": "Fee Exemptions",
+        "section_name": "About your application",
+        "policy_refs": [
+          {
+            "text": "UK Statutory Instruments 2012 No. 2920 Regulation 8"
+          }
+        ]
+      },
+      "question": "When did the original application time out?"
+    },
+    {
+      "responses": [
+        {
+          "value": "No"
+        }
+      ],
+      "metadata": {
+        "portal_name": "Fee exemptions and adjustments",
+        "auto_answered": true,
+        "section_name": "About your application"
+      },
+      "question": "Does the application qualify for a disability exemption?"
+    },
+    {
+      "responses": [
+        {
+          "value": "Yes"
+        }
+      ],
+      "metadata": {
+        "portal_name": "Fee exemptions and adjustments",
+        "auto_answered": true,
+        "section_name": "About your application"
+      },
+      "question": "Does the application qualify for a resubmission exemption?"
+    },
+    {
+      "responses": [
+        {
+          "value": "No"
+        }
+      ],
+      "metadata": {
+        "portal_name": "pre-app-advice-check",
+        "section_name": "About your application"
+      },
+      "question": "Did you get any pre-application advice before making this application?"
+    },
+    {
+      "responses": [
+        {
+          "value": "None of the above apply to me"
+        }
+      ],
+      "metadata": {
+        "portal_name": "declarations",
+        "section_name": "Review"
+      },
+      "question": "Connections with Buckinghamshire Council"
+    },
+    {
+      "responses": [
+        {
+          "value": "The information contained in this application is truthful, accurate and complete, to the best of my knowledge"
+        }
+      ],
+      "metadata": {
+        "portal_name": "declarations",
+        "section_name": "Review"
+      },
+      "question": "I confirm that:"
+    },
+    {
+      "responses": [
+        {
+          "value": "South Buckinghamshire"
+        }
+      ],
+      "metadata": {
+        "portal_name": "uniform-translator",
+        "auto_answered": true,
+        "section_name": "Review"
+      },
+      "question": "What local planning authority is this application being sent to?"
+    },
+    {
+      "responses": [
+        {
+          "value": "Lawful Development Certificate"
+        }
+      ],
+      "metadata": {
+        "portal_name": "uniform-translator",
+        "auto_answered": true,
+        "section_name": "Review"
+      },
+      "question": "What type of application is it?"
+    },
+    {
+      "responses": [
+        {
+          "value": "Proposed"
+        }
+      ],
+      "metadata": {
+        "portal_name": "uniform-translator",
+        "auto_answered": true,
+        "section_name": "Review"
+      },
+      "question": "What type of works are you applying about?"
+    },
+    {
+      "responses": [
+        {
+          "value": "Owner"
+        }
+      ],
+      "metadata": {
+        "portal_name": "uniform-translator",
+        "auto_answered": true,
+        "section_name": "Review"
+      },
+      "question": "What is the applicant's interest in the land?"
+    },
+    {
+      "responses": [
+        {
+          "value": "Applicant"
+        }
+      ],
+      "metadata": {
+        "portal_name": "uniform-translator",
+        "auto_answered": true,
+        "section_name": "Review"
+      },
+      "question": "What is the user's role?"
+    },
+    {
+      "responses": [
+        {
+          "value": "None"
+        }
+      ],
+      "metadata": {
+        "portal_name": "uniform-translator",
+        "auto_answered": true,
+        "section_name": "Review"
+      },
+      "question": "What is the applicant's declared connections?"
+    },
+    {
+      "responses": [
+        {
+          "value": "No"
+        }
+      ],
+      "metadata": {
+        "portal_name": "_root",
+        "auto_answered": true,
+        "section_name": "Review"
+      },
+      "question": "Does the application qualify for a disability exemption?"
+    },
+    {
+      "responses": [
+        {
+          "value": "Yes"
+        }
+      ],
+      "metadata": {
+        "portal_name": "_root",
+        "auto_answered": true,
+        "section_name": "Review"
+      },
+      "question": "Does the application qualify for a resubmission exemption?"
+    }
+  ],
+  "files": [
+    {
+      "filename": "http://localhost:7002/file/private/pizza-user-uploads/26fhsw68/Screenshot%202023-03-13%20at%2016.33.24.png",
+      "tags": [
+        "Existing",
+        "Plan"
+      ]
+    },
+    {
+      "filename": "http://localhost:7002/file/private/pizza-user-uploads/usy0uel6/Screenshot%202023-03-13%20at%2016.33.24.png",
+      "tags": [
+        "Proposed",
+        "Plan"
+      ]
+    },
+    {
+      "filename": "http://localhost:7002/file/private/pizza-user-uploads/b3ttfvme/Screenshot%202023-03-13%20at%2016.33.24.png",
+      "tags": [
+        "Existing",
+        "Elevation"
+      ]
+    },
+    {
+      "filename": "http://localhost:7002/file/private/pizza-user-uploads/bpv1cjqf/Screenshot%202023-03-13%20at%2016.33.24.png",
+      "tags": [
+        "Proposed",
+        "Elevation"
+      ]
+    }
+  ],
+  "geojson": {
+    "geometry": {
+      "coordinates": [
+        [
+          [
+            -0.6337644159793875,
+            51.60562104546682
+          ],
+          [
+            -0.6334143877029441,
+            51.605623544229644
+          ],
+          [
+            -0.6338289290590076,
+            51.60546161233182
+          ],
+          [
+            -0.6337644159793875,
+            51.60562104546682
+          ]
+        ]
+      ],
+      "type": "Polygon"
+    },
+    "type": "Feature",
+    "properties": null
+  },
+  "session_id": "6d2a14fa-b683-4a25-827f-a3bf97148090"
+}

--- a/data/exampleWithSections.json
+++ b/data/exampleWithSections.json
@@ -1,6 +1,59 @@
 {
   "data": [
     {
+      "question": "Planning Application Reference",
+      "responses": "fcdaabb2-1feb-47cb-94fa-f9d5148b2efb"
+    },
+    {
+      "question": "result",
+      "responses": {
+        "flag": "Planning permission / Not development",
+        "heading": "Not development",
+        "description": "It looks like the proposed changes may not fall within the legal definition of ‘development’, and therefore would not require planning permission."
+      }
+    },
+    {
+      "question": "site",
+      "responses": {
+        "town": "HIGH WYCOMBE",
+        "uprn": "200000797602",
+        "latitude": 51.6274191,
+        "postcode": "HP11 1BB",
+        "address_1": "BUCKINGHAMSHIRE COUNCIL, COUNCIL OFFICES, QUEEN VICTORIA ROAD",
+        "longitude": -0.7489513
+      }
+    },
+    {
+      "question": "boundary_geojson",
+      "responses": {
+        "type": "Feature",
+        "geometry": {
+          "type": "Polygon",
+          "coordinates": [
+            [
+              [
+                -0.7491888117037445,
+                51.62746573090956
+              ],
+              [
+                -0.7487475045017631,
+                51.627460469121615
+              ],
+              [
+                -0.7490133156060904,
+                51.627360716173484
+              ],
+              [
+                -0.7491888117037445,
+                51.62746573090956
+              ]
+            ]
+          ]
+        },
+        "properties": null
+      }
+    },
+    {
       "responses": [
         {
           "value": "Yes"

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "@mui/material": "5.11.9",
     "@rollup/plugin-commonjs": "^23.0.3",
     "docx": "^7.8.2",
+    "lodash.groupby": "^4.6.0",
     "lodash.startcase": "^4.4.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
@@ -42,6 +43,7 @@
     "@babel/core": "^7.20.5",
     "@babel/plugin-syntax-flow": "^7.18.6",
     "@babel/plugin-transform-react-jsx": "^7.19.0",
+    "@types/lodash.groupby": "^4.6.7",
     "@types/lodash.startcase": "^4.4.7",
     "@types/node": "^18.11.18",
     "@types/react": "^18.0.25",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,6 +9,7 @@ specifiers:
   '@lit-labs/ssr': ^2.2.3
   '@mui/material': 5.11.9
   '@rollup/plugin-commonjs': ^23.0.3
+  '@types/lodash.groupby': ^4.6.7
   '@types/lodash.startcase': ^4.4.7
   '@types/node': ^18.11.18
   '@types/react': ^18.0.25
@@ -20,6 +21,7 @@ specifiers:
   eslint: ^8.28.0
   eslint-config-prettier: ^8.5.0
   eslint-config-react-app: ^7.0.1
+  lodash.groupby: ^4.6.0
   lodash.startcase: ^4.4.0
   prettier: ^2.8.0
   react: ^18.2.0
@@ -36,6 +38,7 @@ dependencies:
   '@mui/material': 5.11.9_thp4wrxo45nyllusrnt46mid4u
   '@rollup/plugin-commonjs': 23.0.3
   docx: 7.8.2
+  lodash.groupby: 4.6.0
   lodash.startcase: 4.4.0
   react: 18.2.0
   react-dom: 18.2.0_react@18.2.0
@@ -44,6 +47,7 @@ devDependencies:
   '@babel/core': 7.20.5
   '@babel/plugin-syntax-flow': 7.18.6_@babel+core@7.20.5
   '@babel/plugin-transform-react-jsx': 7.19.0_@babel+core@7.20.5
+  '@types/lodash.groupby': 4.6.7
   '@types/lodash.startcase': 4.4.7
   '@types/node': 18.11.18
   '@types/react': 18.0.25
@@ -1891,6 +1895,12 @@ packages:
     resolution: {integrity: sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==}
     dev: true
 
+  /@types/lodash.groupby/4.6.7:
+    resolution: {integrity: sha512-dFUR1pqdMgjIBbgPJ/8axJX6M1C7zsL+HF4qdYMQeJ7XOp0Qbf37I3zh9gpXr/ks6tgEYPDRqyZRAnFYvewYHQ==}
+    dependencies:
+      '@types/lodash': 4.14.191
+    dev: true
+
   /@types/lodash.startcase/4.4.7:
     resolution: {integrity: sha512-6v8FVOcfxdomO1Vammc1Zsah7/4aif/Lx16oQQ0WZmKVGF/Yf5c5m68LqI/ELOhKaKUr8KfnDdKrytdrThoRQw==}
     dependencies:
@@ -3703,6 +3713,10 @@ packages:
   /lodash.debounce/4.0.8:
     resolution: {integrity: sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==}
     dev: true
+
+  /lodash.groupby/4.6.0:
+    resolution: {integrity: sha512-5dcWxm23+VAoz+awKmBaiBvzox8+RqMgFhi7UvX9DHZr2HdxHXM/Wrf8cfKpsW37RNrvtPn6hSwNqurSILbmJw==}
+    dev: false
 
   /lodash.merge/4.6.2:
     resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}

--- a/scripts/generateTemplateExamples.ts
+++ b/scripts/generateTemplateExamples.ts
@@ -15,6 +15,7 @@ import { buildTestTemplate } from "../src/templates/testTemplate";
 import exampleLDCEData from "../data/exampleLDCE.json";
 import exampleLDCPData from "../data/exampleLDCP.json";
 import exampleData from "../data/example.json";
+import exampleSectionData from "../data/exampleWithSections.json";
 
 (async () => {
   try {
@@ -35,6 +36,7 @@ async function setUpExampleDir() {
 
 async function generateHTMLExamples() {
   const data = exampleData.data;
+  const sectionData = exampleSectionData.data;
   const geojson = exampleData.geojson;
 
   const promises: Promise<void>[] = [];
@@ -42,6 +44,10 @@ async function generateHTMLExamples() {
   const htmlFile = createWriteStream(`./examples/Overview.html`);
   const htmlStream = generateHTMLOverviewStream(data).pipe(htmlFile);
   promises.push(resolveStream(htmlStream));
+
+  const sectionHtmlFile = createWriteStream(`./examples/Overview_with_sections.html`);
+  const sectionHtmlStream = generateHTMLOverviewStream(sectionData).pipe(sectionHtmlFile);
+  promises.push(resolveStream(sectionHtmlStream));
 
   const mapFile = createWriteStream(`./examples/LocationPlan.html`);
   const mapStream = generateHTMLMapStream(geojson).pipe(mapFile);

--- a/src/Main.tsx
+++ b/src/Main.tsx
@@ -3,8 +3,7 @@ import Tab from "@mui/material/Tab";
 import Tabs from "@mui/material/Tabs";
 import React, { useState } from "react";
 import ReactDOM from "react-dom/client";
-
-import example from "./data/example.json";
+import example from "../data/exampleWithSections.json";
 import { BoundaryMapDocument } from "./map/BoundaryMapDocument";
 import { OverviewDocument } from "./overview/OverviewDocument";
 

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -69,7 +69,7 @@ describe("generateHTMLOverviewStream", () => {
   test("it creates a readable stream", () => {
     expect(
       generateHTMLOverviewStream([
-        { question: "?", responses: { value: "yes" }, metadata: { q: "a" } },
+        { question: "?", responses: { value: "yes" }, metadata: { section_name: "First section" } },
       ])
     ).toBeTruthy();
   });

--- a/src/overview/OverviewDocument.tsx
+++ b/src/overview/OverviewDocument.tsx
@@ -126,21 +126,15 @@ function Boundary(props: { data: PlanXExportData[] }): JSX.Element {
   );
 }
 
-function ProposalDetails(props: { data: PlanXExportData[] }): JSX.Element {
-  const hasSections = props.data.some(response => response.metadata?.section_name);
+function ProposalDetails(props: { data: PlanXExportData[], title?: string }): JSX.Element {
   return (
     <Box>
-      { hasSections ? 
-        <SectionList data={props.data} /> : 
-        <>
-          <h2>Proposal details</h2>
-          <Box component="dl" sx={gridStyles}>
-            {props.data.map((item, index) => (
-              <DataItem key={index} data={item} />
-            ))}
-          </Box>
-        </>
-      }
+      <h2>{props.title || "Proposal details"}</h2>
+      <Box component="dl" sx={gridStyles}>
+        {props.data.map((item, index) => (
+          <DataItem key={index} data={item} />
+        ))}
+      </Box>
     </Box>
   );
 }
@@ -150,29 +144,11 @@ function SectionList(props: { data: PlanXExportData[] }) {
   return (
     <>
       {
-        Object.entries(sections).map(([title, data]) => (
-          <section key={title}>
-            <h2>{title}</h2>
-            <DataList data={data} />
-          </section>
+        Object.entries(sections).map(([title, data], index) => (
+          data.length && <ProposalDetails data={data} title={title} key={index}/> 
         ))
       }
     </>
-  );
-}
-
-function DataList(props: { data: PlanXExportData[] }) {
-  const hasValidDataStructure = validatePlanXExportData(props.data);
-  return (
-    <React.Fragment>
-      {hasValidDataStructure ? (
-        props.data.map((item: PlanXExportData, index: number) => (
-          <DataItem key={index} data={item} />
-        ))
-      ) : (
-        <p>Data not available</p>
-      )}{" "}
-    </React.Fragment>
   );
 }
 
@@ -222,6 +198,7 @@ export function OverviewDocument(props: { data: PlanXExportData[] }) {
     "result",
   ];
   const filteredProposalDetails = props.data.filter(d => !removeableQuestions.includes(d.question));
+  const hasSections = props.data.some(response => response.metadata?.section_name);
 
   return (
     <html>
@@ -267,7 +244,10 @@ export function OverviewDocument(props: { data: PlanXExportData[] }) {
               <Box sx={{ display: "flex" }}>
                 <Boundary data={props.data} />
               </Box>
-              <ProposalDetails data={filteredProposalDetails} />
+              { hasSections ?
+                <SectionList data={filteredProposalDetails}/> :
+                <ProposalDetails data={filteredProposalDetails}/>
+              }
             </>
           )}
         </Grid>

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,8 +1,16 @@
 export interface PlanXExportData {
   question: string;
   responses: unknown;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  metadata?: any;
+  metadata?: {
+    portal_name?: string;
+    section_name?: string;
+    policy_refs?: PolicyRefs[];
+    flags?: string[];
+  };
+}
+
+export interface PolicyRefs {
+  text: string;
 }
 
 export interface Passport {


### PR DESCRIPTION
<img width="805" alt="image" src="https://user-images.githubusercontent.com/20502206/225140702-89efb287-8822-46ed-b200-c9b91f773f66.png">


Follows on from https://github.com/theopensystemslab/planx-new/pull/1527 in order to complete ticket https://trello.com/c/R9b4hKmo/2298-99-add-section-markers-to-overviewhtml-layout

Not done much on styling here, but the card pattern here has been suggested as an option - https://design-system.service.gov.uk/components/summary-list/