### PR TITLE
Update license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,5 @@
-The Open Government Licence (OGL) Version 3
+The Mozilla Public License (MPL) Version 2
 
-Copyright (c) 2021
+Copyright (c) 2023
 
-This source code is licensed under the Open Government Licence v3.0. To view this
-licence, visit http://www.nationalarchives.gov.uk/doc/open-government-licence/version/3
+This source code is licensed under the Mozilla Public License v2.0. To view this license, visit https://mozilla.org/MPL/2.0/

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@opensystemslab/planx-document-templates",
   "version": "1.0.0",
-  "license": "OGL-UK-3.0",
+  "license": "MPL-2.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/theopensystemslab/planx-document-templates.git"


### PR DESCRIPTION
OSL/Planx service content is licensed via OGL, but our code should be distributed via MPL 2.0 for consistency with planx-new